### PR TITLE
Update json structure

### DIFF
--- a/nexustreetojson.py
+++ b/nexustreetojson.py
@@ -4,6 +4,12 @@ import numpy as np
 
 
 def _name_to_json(tree):
+    """
+    Create line of JSON defining the group or dataset's name
+
+    :param tree: Group or dataset tree node
+    :return: Line of JSON defining the name
+    """
     return '"name": "' + tree.nxname + '"'
 
 
@@ -12,6 +18,12 @@ def _is_array(possible_array):
 
 
 def _attrs_to_json(tree):
+    """
+    Creates a list of lines of JSON for the attributes of a given group or dataset
+
+    :param tree: Group or dataset tree node
+    :return: List of lines of JSON
+    """
     result = []
     if tree.attrs:
         for k in tree.attrs:
@@ -38,6 +50,12 @@ def _attrs_to_json(tree):
 
 
 def _tree_to_json_string(tree):
+    """
+    Create a JSON string describing the NeXus file
+
+    :param tree: Root node of the tree
+    :return: JSON string (not pretty)
+    """
     result = []
     children_prepend = ""
     children_append = ""
@@ -68,6 +86,12 @@ def _tree_to_json_string(tree):
 
 
 def tree_to_json(tree):
+    """
+    Create a JSON string describing the NeXus file
+
+    :param tree: Root node of the tree
+    :return: Formatted JSON string
+    """
     json_tree = _tree_to_json_string(tree)
     parsed = json.loads(json_tree)
     beautified_json_tree = json.dumps(parsed, indent=2, sort_keys=False)

--- a/nexustreetojson.py
+++ b/nexustreetojson.py
@@ -2,6 +2,13 @@ import nexusformat.nexus
 import json
 import numpy as np
 
+"""
+Creates a JSON string of the structure of an existing NeXus file in the format for kafka-to-nexus.
+
+It is intended to be helpful in creating examples of the JSON command.
+Currently omits values of datasets; typically these would be populated from Kafka streams. 
+"""
+
 
 def _name_to_json(tree):
     """

--- a/nexustreetojson.py
+++ b/nexustreetojson.py
@@ -37,6 +37,11 @@ def _tree_to_json_string(tree):
     if tree.attrs:
         result.append(_attrs_to_json(tree))
 
+    if tree.nxclass is "NXfield":
+        result.append('"type": "dataset"')
+    else:
+        result.append('"type": "group"')
+
     if hasattr(tree, 'entries'):
         entries = tree.entries
         if entries:
@@ -53,7 +58,7 @@ def _tree_to_json_string(tree):
 def tree_to_json(tree):
     json_tree = _tree_to_json_string(tree)
     parsed = json.loads(json_tree)
-    beautified_json_tree = json.dumps(parsed, indent=2, sort_keys=True)
+    beautified_json_tree = json.dumps(parsed, indent=2, sort_keys=False)
     return beautified_json_tree
 
 

--- a/nexustreetojson.py
+++ b/nexustreetojson.py
@@ -59,7 +59,7 @@ def _tree_to_json_string(tree):
     result = []
     children_prepend = ""
     children_append = ""
-    if tree.nxname is "root" and tree.nxclass is not "NXfield":
+    if isinstance(tree, nexusformat.nexus.NXroot):
         children_prepend = '{"nexus_structure": {'
         children_append = '}'
     else:


### PR DESCRIPTION
Closes #1 

Changes to match those in kafka-to-nexus:
- Attributes are now dictionaries instead of lists
- Datasets and groups are identified by a `"type"` field
- `NX_class` type is recorded in the attributes